### PR TITLE
Change parallelism of HDFS tests to 2 instead of 4

### DIFF
--- a/catalog/testsuites.yaml
+++ b/catalog/testsuites.yaml
@@ -272,26 +272,26 @@
         zookeeper-operator: NIGHTLY
   platforms: 
     - name: hcloud-k3s-centos-8
-      test_params: --parallel 4
+      test_params: --parallel 2
     - name: hcloud-k3s-centos-9
-      test_params: --parallel 4
+      test_params: --parallel 2
     - name: hcloud-k3s-debian-10
-      test_params: --parallel 4
+      test_params: --parallel 2
     - name: ionos-k3s-centos-8
-      test_params: --parallel 4
+      test_params: --parallel 2
     - name: ionos-k3s-debian-11
-      test_params: --parallel 4
+      test_params: --parallel 2
     - name: ionos-k8s
-      test_params: --parallel 4
+      test_params: --parallel 2
     - name: azure-aks
-      test_params: --parallel 4
+      test_params: --parallel 2
     - name: aws-eks
-      test_params: --parallel 4
+      test_params: --parallel 2
       cluster_definition_overlay: |
         spec:
           awsInstanceType: "t2.large"
     - name: gke
-      test_params: --parallel 4
+      test_params: --parallel 2
   nightly_test:
     platform: "'random(aws-eks)'"
     slack_channels: "#product-hdfs"


### PR DESCRIPTION
Malte was seeing issues with resource limits getting reached in recent HDFS tests: https://ci.stackable.tech/job/hdfs-operator-it-custom/23/artifact/testsuite/target/testdriver.log

Which would indicate an issue with too high resource claims, we wanted to run a custom test with `parallel=2` but according to our understanding we need to configure that on the nightly test runs for it to be effective in the custom ones as well.