### PR TITLE
Run only two hbase-operator integration tests in parallel

### DIFF
--- a/catalog/testsuites.yaml
+++ b/catalog/testsuites.yaml
@@ -197,7 +197,7 @@ operator_tests:
           zookeeper-operator: DEV
     platforms:
       - name: ionos-k8s
-        test_params: --parallel 4
+        test_params: --parallel 2
         cluster_definition_overlay: |
           spec:
             nodes:
@@ -205,14 +205,14 @@ operator_tests:
               numberOfCores: 4
               memoryMb: 32768
       - name: azure-aks
-        test_params: --parallel 4
+        test_params: --parallel 2
         cluster_definition_overlay: |
           spec:
             nodes:
               count: 3
               vmSize: Standard_D8s_v3
       - name: gke
-        test_params: --parallel 4
+        test_params: --parallel 2
         cluster_definition_overlay: |
           spec:
             nodes:
@@ -250,7 +250,7 @@ operator_tests:
                 count: 8
                 serverType: cpx41
       - name: ionos-k3s-rocky-8
-        test_params: --parallel 4
+        test_params: --parallel 2
         cluster_definition_overlay: |
           spec:
             nodes:
@@ -259,7 +259,7 @@ operator_tests:
                 numberOfCores: 4
                 memoryMb: 32768
       - name: ionos-k3s-debian-10
-        test_params: --parallel 4
+        test_params: --parallel 2
         cluster_definition_overlay: |
           spec:
             nodes:
@@ -268,7 +268,7 @@ operator_tests:
                 numberOfCores: 4
                 memoryMb: 32768
       - name: ionos-k3s-debian-11
-        test_params: --parallel 4
+        test_params: --parallel 2
         cluster_definition_overlay: |
           spec:
             nodes:


### PR DESCRIPTION
Run only two hbase-operator integration tests in parallel

The integration tests are sometimes blocked due to insufficient resources. Timeouts occur and the tests fail. Decreasing the tests running in parallel from 4 to 2, solved the resource issues. However, the duration of the nightly test suite increased from 26 minutes to 38 minutes.