### PR TITLE
Increase the waiting period after cluster creation

### DIFF
--- a/tools/testing-toolbox/templates/test-docs.sh.j2
+++ b/tools/testing-toolbox/templates/test-docs.sh.j2
@@ -1,6 +1,6 @@
 #!/bin/bash
 # wait a minute for cluster to be REALLY ready
-sleep 60
+sleep 120
 
 {% if git_branch %}
 git clone -b {{ git_branch }} https://github.com/stackabletech/{{ testsuite.git_repo }}.git

--- a/tools/testing-toolbox/templates/test.sh.j2
+++ b/tools/testing-toolbox/templates/test.sh.j2
@@ -1,6 +1,6 @@
 #!/bin/bash
 # wait a minute for cluster to be REALLY ready
-sleep 60
+sleep 120
 
 # Install tool for test suite expansion
 pip install beku-stackabletech


### PR DESCRIPTION
The installation of the Stackable release often fails on IONOS clusters with the following error:

```
DEBUG:root:Running : ['stackablectl', 'release', 'install', '--release-file', '/tmp/patched9fuxgibt', 'tests']
ERROR:root:An unrecoverable error occured: failed to execute release (sub)command

Caused by these errors (recent errors listed first):
 1: failed to install release
 2: failed to install release using Helm
 3: failed to install Helm release
 4: helm FFI library call failed (failed to install CRD crds/crds.yaml

ERROR:root:stackablectl failed
```

There seems to be no corresponding Kubernetes event in the logs.

Starting the tests again, works sometimes, so the CRDs are not broken.

The reason is not clear. It could be that the cluster is not ready yet.

The current solution is to increase the waiting period after the cluster creation to see if this fixes the problem.