### PR TITLE
Wait for nodes and kube-system pods to be ready

### DIFF
--- a/tools/testing-toolbox/templates/test-docs.sh.j2
+++ b/tools/testing-toolbox/templates/test-docs.sh.j2
@@ -1,6 +1,8 @@
 #!/bin/bash
-# wait a minute for cluster to be REALLY ready
-sleep 120
+
+# Wait for the cluster to be REALLY ready
+kubectl wait --for=condition=Ready nodes --all --timeout=10m
+kubectl wait --for=condition=Ready pods --namespace kube-system --all --timeout=10m
 
 {% if git_branch %}
 git clone -b {{ git_branch }} https://github.com/stackabletech/{{ testsuite.git_repo }}.git

--- a/tools/testing-toolbox/templates/test.sh.j2
+++ b/tools/testing-toolbox/templates/test.sh.j2
@@ -1,6 +1,8 @@
 #!/bin/bash
-# wait a minute for cluster to be REALLY ready
-sleep 120
+
+# Wait for the cluster to be REALLY ready
+kubectl wait --for=condition=Ready nodes --all --timeout=10m
+kubectl wait --for=condition=Ready pods --namespace kube-system --all --timeout=10m
 
 # Install tool for test suite expansion
 pip install beku-stackabletech


### PR DESCRIPTION
The installation of the Stackable release sometimes fails on IONOS clusters. Helm reports one of the following errors:

* failed to install CRD crds/crds.yaml
* context deadline exceeded
* 1 error occurred (The complete error message was cut off by stackablectl, see stackabletech/stackable-cockpit#303)

The situation improved by increasing the waiting period after the cluster creation from one to two minutes (#117), but it did not fix the issue.

Instead of a waiting period, this pull request tries to wait for all nodes and the pods in the kube-system namespace to be ready.