### PR TITLE
fix: Increase test-cluster TTL to 6h

### DIFF
--- a/apps/src/modules/provider_replicated.py
+++ b/apps/src/modules/provider_replicated.py
@@ -14,7 +14,7 @@ def api_call_create_cluster(cluster_name, spec, platform_version, logger):
         platform_version    version of the (K8s) platform
         logger              logger (String-consuming function)
     """
-    command = f"replicated cluster create --name {cluster_name} --distribution {spec['distribution']} --instance-type {spec['instance-type']} --version {platform_version} --disk {spec['disk-size']} --nodes {spec['node-count']} --ttl 4h"
+    command = f"replicated cluster create --name {cluster_name} --distribution {spec['distribution']} --instance-type {spec['instance-type']} --version {platform_version} --disk {spec['disk-size']} --nodes {spec['node-count']} --ttl 6h"
     logger(f"System call: --> {command}")
     exit_code, output = run_command(command, 'replicated cluster create')
     if exit_code != 0:


### PR DESCRIPTION
As HDFS tests can take longer than 4 hours, currently this deletes the k8s before the test finished, resulting in
`Get "https://cluster-dns-1nvkkrsm.hcp.eastus.azmk8s.io:443/apis/apps/v1/namespaces/kuttl-test-fond-chipmunk/statefulsets/test-hdfs-automatic-log-namenode-default": dial tcp: lookup cluster-dns-1nvkkrsm.hcp.eastus.azmk8s.io on 8.8.8.8:53: no such host`.

Discussed in https://github.com/replicated-collab/stackable-replicated/issues/7