### PR TITLE
fix: update aks instance type

### DIFF
--- a/catalog/platforms.yaml
+++ b/catalog/platforms.yaml
@@ -21,13 +21,12 @@ platforms:
     name: "Azure AKS on replicated.com"
     provider: replicated
     versions:
+      - "1.32"
       - "1.31"
       - "1.30"
-      - "1.29"
-      - "1.28"
     spec:
       distribution: aks
-      instance-type: Standard_DS3_v2
+      instance-type: Standard_D4S_v5
       disk-size: 100
       node-count: 3
   - id: replicated-aws


### PR DESCRIPTION
Fixes:

```
['Error: instance type "Standard_DS3_v2" is not supported for distribution "aks"']
```