### PR TITLE
Disable cache in docker build

### DIFF
--- a/apps/build.sh
+++ b/apps/build.sh
@@ -10,7 +10,7 @@ rm -rf docker/operator-test-runner/src/
 cp -r src/ docker/operator-test-runner/src/
 
 # build Docker image
-docker build docker/operator-test-runner/ -t oci.stackable.tech/operator-test-runner:latest
+docker build --no-cache docker/operator-test-runner/ -t oci.stackable.tech/operator-test-runner:latest
 
 # copy resources
 rm -rf docker/jenkins-job-builder/catalog/
@@ -22,4 +22,4 @@ rm -rf docker/jenkins-job-builder/jjb/
 cp -r jjb/ docker/jenkins-job-builder/jjb/
 
 # build Docker image
-docker build docker/jenkins-job-builder/ -t oci.stackable.tech/jenkins-job-builder:latest
+docker build --no-cache docker/jenkins-job-builder/ -t oci.stackable.tech/jenkins-job-builder:latest


### PR DESCRIPTION
Disable cache in docker build

Otherwise stackablectl is not updated in the image `oci.stackable.tech/operator-test-runner:latest`.