### PR TITLE
Invalidate Docker cache

### DIFF
--- a/apps/build.sh
+++ b/apps/build.sh
@@ -10,7 +10,7 @@ rm -rf docker/operator-test-runner/src/
 cp -r src/ docker/operator-test-runner/src/
 
 # build Docker image
-docker build --no-cache docker/operator-test-runner/ -t oci.stackable.tech/operator-test-runner:latest
+docker build docker/operator-test-runner/ -t oci.stackable.tech/operator-test-runner:latest
 
 # copy resources
 rm -rf docker/jenkins-job-builder/catalog/
@@ -22,4 +22,4 @@ rm -rf docker/jenkins-job-builder/jjb/
 cp -r jjb/ docker/jenkins-job-builder/jjb/
 
 # build Docker image
-docker build --no-cache docker/jenkins-job-builder/ -t oci.stackable.tech/jenkins-job-builder:latest
+docker build docker/jenkins-job-builder/ -t oci.stackable.tech/jenkins-job-builder:latest

--- a/apps/docker/operator-test-runner/Dockerfile
+++ b/apps/docker/operator-test-runner/Dockerfile
@@ -1,6 +1,8 @@
 # From ubuntu 24.04 LTS
 FROM ubuntu@sha256:b59d21599a2b151e23eea5f6602f4af4d7d31c4e236d22bf0b62b86d2e386b8f
 
+RUN echo "Invalidate cache"
+
 RUN apt update && \
     apt install -y \
        git \


### PR DESCRIPTION
`docker build --no-cache` was not run in Jenkins. Try to invalidate the cache by creating a new temporary layer in the Dockerfile.