### PR TITLE
fix: pin jenkins-job-builder dependencies to latest

### DIFF
--- a/apps/docker/jenkins-job-builder/python_modules
+++ b/apps/docker/jenkins-job-builder/python_modules
@@ -1,5 +1,5 @@
-pyyaml
-requests
-HiYaPyCo
-jinja2
+pyyaml==6.0.3
+requests==2.32.5
+HiYaPyCo==0.7.0
+jinja2==3.1.6
 jenkins-job-builder


### PR DESCRIPTION
The jjb script throws runtime errors due to missing packages (that have been removed from 3.14) and it doesn't update the operator versions list.

See: https://testing.stackable.tech/view/09%20Maintenance/job/maintenance-jenkins-job-builder/170079/console

The image builds locally but it needs to run on Jenkins. I cannot test it here.