### PR TITLE
fix(security): prevent shell injection from Jenkins job parameters

### DIFF
--- a/apps/src/modules/cluster_logging.py
+++ b/apps/src/modules/cluster_logging.py
@@ -6,6 +6,8 @@ This module installs the "cluster logging" on a test cluster.
 log index.
 """
 
+import shlex
+
 from modules.command import run_command
 
 
@@ -22,7 +24,8 @@ def install_cluster_logging(cluster_id, endpoint, username, password, logger):
 
     logger("Creating configmap 'cluster-metadata' to be used by Vector aggretator and agent...")
     exit_code, output = run_command(
-        f"kubectl create configmap cluster-metadata --from-literal=T2_CLUSTER_ID={cluster_id}",
+        f"kubectl create configmap cluster-metadata "
+        f"--from-literal=T2_CLUSTER_ID={shlex.quote(str(cluster_id))}",
         "create configmap cluster-metadata",
     )
     if exit_code != 0:
@@ -32,7 +35,10 @@ def install_cluster_logging(cluster_id, endpoint, username, password, logger):
 
     logger("Create secret containing the credentials and endpoint for target logging system...")
     exit_code, output = run_command(
-        f"kubectl create secret generic cluster-logging-target  --from-literal=endpoint='{endpoint}' --from-literal=user='{username}' --from-literal=password='{password}'",
+        f"kubectl create secret generic cluster-logging-target "
+        f"--from-literal=endpoint={shlex.quote(endpoint)} "
+        f"--from-literal=user={shlex.quote(username)} "
+        f"--from-literal=password={shlex.quote(password)}",
         "create secret for logging target",
     )
     if exit_code != 0:

--- a/apps/src/operator-test-runner.py
+++ b/apps/src/operator-test-runner.py
@@ -3,6 +3,7 @@ Main module of the Operator Test Runner application
 """
 
 import os
+import shlex
 import sys
 import uuid
 from datetime import UTC, datetime, timedelta
@@ -151,7 +152,7 @@ def set_target_folder_owner():
     That's why a UID/GID combo is to be specified as the OUTPUT_FILE_USER env var.
     This method recursively sets the ownership of the output files.
     """
-    os.system(f"chown -R {param_output_file_user} {TARGET_FOLDER}")
+    os.system(f"chown -R {shlex.quote(param_output_file_user)} {TARGET_FOLDER}")
 
 
 def log(msg=""):
@@ -169,9 +170,11 @@ def clone_git_repo(repo):
     """
     Clones the given Stackable GitHub repo
     """
-    git_branch_option = f"-b {param_git_branch}" if param_git_branch else ""
+    git_branch_option = f"-b {shlex.quote(param_git_branch)}" if param_git_branch else ""
     exit_code, output = run_command(
-        f"git clone {git_branch_option} https://github.com/stackabletech/{repo}.git", "git clone"
+        f"git clone {git_branch_option} "
+        f"https://github.com/stackabletech/{shlex.quote(repo)}.git",
+        "git clone",
     )
     if exit_code != 0:
         for line in output:
@@ -207,7 +210,11 @@ def run_tests(operator, operator_version, test_script_params):
 
     # Step 1: Installation of the SDP (retried max. 10 times to reduce flakiness)
     # This step is always done with run-tests regardless of the test script choice
-    command_install_sdp = f"cd {operator}/ && python ./scripts/run-tests --skip-tests --operator {operator.replace('-operator', '')}={operator_version}"
+    operator_name = operator.replace("-operator", "")
+    command_install_sdp = (
+        f"cd {shlex.quote(operator)}/ && python ./scripts/run-tests --skip-tests "
+        f"--operator {shlex.quote(operator_name)}={shlex.quote(operator_version)}"
+    )
     log("Running the following command to install SDP for test:")
     log(command_install_sdp)
     exit_code, output = run_command(command_install_sdp, "install sdp", retries=10, delay=60)
@@ -239,10 +246,10 @@ def run_tests(operator, operator_version, test_script_params):
 
         # Build command for auto-retry-tests.py
         command_parts = [
-            f"cd {operator}/",
+            f"cd {shlex.quote(operator)}/",
             "&&",
             "python ./scripts/auto-retry-tests.py",
-            f"--parallel {parallel_value}",
+            f"--parallel {shlex.quote(parallel_value)}",
             f"--attempts-parallel {retry_config['attempts_parallel']}",
             f"--attempts-serial {retry_config['attempts_serial']}",
             f"--output-dir {TARGET_FOLDER}test-results",
@@ -265,7 +272,7 @@ def run_tests(operator, operator_version, test_script_params):
 
         if extra_params:
             command_parts.append("--extra-args")
-            command_parts.extend(extra_params)
+            command_parts.extend(shlex.quote(param) for param in extra_params)
 
         command_parts.extend(["2>&1", ";", "echo $? > /test_exit_code"])
         command_run_tests = f"({' '.join(command_parts)}) | tee {TEST_OUTPUT_LOGFILE}"
@@ -273,7 +280,11 @@ def run_tests(operator, operator_version, test_script_params):
     else:
         # Use traditional run-tests script
         params = " --log-level debug" if "--log-level" not in test_script_params else ""
-        command_run_tests = f"(cd {operator}/ && python ./scripts/run-tests --skip-release {params} {test_script_params} 2>&1; echo $? > /test_exit_code) | tee {TEST_OUTPUT_LOGFILE}"
+        safe_params = " ".join(shlex.quote(tok) for tok in test_script_params.split())
+        command_run_tests = (
+            f"(cd {shlex.quote(operator)}/ && python ./scripts/run-tests --skip-release"
+            f"{params} {safe_params} 2>&1; echo $? > /test_exit_code) | tee {TEST_OUTPUT_LOGFILE}"
+        )
 
     log("Running the following test command:")
     log(command_run_tests)


### PR DESCRIPTION
## Security fix (blocker)

The operator test runner spliced free-text Jenkins job parameters directly into shell command strings run via `os.system()` / `run_command()` (`/bin/bash -c`). Anyone able to trigger an `*-it-custom` test job could achieve **arbitrary code execution** inside a container holding `REPLICATED_API_TOKEN`, IONOS credentials, and the cluster kubeconfig.

### Injection points closed (all `shlex.quote()`d)
`apps/src/operator-test-runner.py`:
- `TEST_SCRIPT_PARAMS` — both the `run-tests` branch and the auto-retry branch (whitespace-split tokens were rejoined verbatim, so `;`/`|`/backticks survived).
- `OUTPUT_FILE_USER` → `chown`.
- `GIT_BRANCH` + repo name → `git clone`.
- `OPERATOR` / `OPERATOR_VERSION` → SDP install command.

`apps/src/modules/cluster_logging.py`:
- OpenSearch `endpoint` / `user` / `password` interpolated into `kubectl create secret` — the hand-written single quotes broke on any value containing a quote. Also the cluster id.

### Verification
- `ruff check apps/` clean; both files parse.
- Demonstrated: a parameter like `foo; touch X` **executes** under the old code and is passed as a **literal argument** under the new code.

### Note
Values are still passed via a shell (the runner relies on `tee`, redirection and `echo $?`), so quoting is the fix; a follow-up could move secrets off the command line entirely (`--from-env-file=`) to also avoid process-list exposure.

Part of the review follow-ups; independent of the other PRs.