### PR TITLE
chore(hardening): cosign checksum, base-image digest pinning, Jenkins secret

### DIFF
--- a/jenkins/jobbuilder.groovy
+++ b/jenkins/jobbuilder.groovy
@@ -44,10 +44,12 @@ pipeline {
             steps {
                 withCredentials([usernamePassword(credentialsId: 'JENKINS_BOT_CREDENTIALS', passwordVariable: 'JENKINS_BOT_PASSWORD', usernameVariable: 'JENKINS_BOT_USERNAME')]) {
                     sh '''
+                        JENKINS_USERNAME="$JENKINS_BOT_USERNAME" \
+                        JENKINS_PASSWORD="$JENKINS_BOT_PASSWORD" \
                         docker run --rm \
                             --env JENKINS_URL=https://testing.stackable.tech \
-                            --env JENKINS_USERNAME=$JENKINS_BOT_USERNAME \
-                            --env JENKINS_PASSWORD=$JENKINS_BOT_PASSWORD \
+                            --env JENKINS_USERNAME \
+                            --env JENKINS_PASSWORD \
                             oci.stackable.tech/jenkins-job-builder:latest
                     '''
                 }

--- a/tools/harbor-garbage-collector/Dockerfile
+++ b/tools/harbor-garbage-collector/Dockerfile
@@ -1,6 +1,6 @@
 FROM oci.stackable.tech/sdp/ubi8-rust-builder AS builder
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal AS operator
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10@sha256:578b238953144445a9b5bb2487eb1d95df4886f98d1f73c4a070b27535f51688 AS operator
 
 ARG VERSION
 ARG RELEASE="1"

--- a/tools/harbor-sbom-browser/Dockerfile
+++ b/tools/harbor-sbom-browser/Dockerfile
@@ -9,6 +9,8 @@ ARG RELEASE="1"
 RUN microdnf install -y yum \
     && yum -y update-minimal --security --sec-severity=Important --sec-severity=Critical \
     && curl -L -O https://github.com/sigstore/cosign/releases/download/v3.0.2/cosign-3.0.2-1.x86_64.rpm \
+    && echo "7b6ae0f1e8da49d196f89245d4014887747c01c215e2e7f41e4853c98a28ed9b  cosign-3.0.2-1.x86_64.rpm" > cosign-3.0.2-1.x86_64.rpm.sha256 \
+    && sha256sum -c cosign-3.0.2-1.x86_64.rpm.sha256 \
     && rpm -ivh cosign-3.0.2-1.x86_64.rpm \
     && yum clean all \
     && microdnf clean all

--- a/tools/monitor-oci-artifacts/Dockerfile
+++ b/tools/monitor-oci-artifacts/Dockerfile
@@ -1,6 +1,6 @@
 FROM oci.stackable.tech/sdp/ubi9-rust-builder AS builder
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal AS operator
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.6@sha256:7c5495d5fad59aaee12abc3cbbd2b283818ee1e814b00dbc7f25bf2d14fa4f0c AS operator
 
 ARG VERSION
 ARG RELEASE="1"
@@ -9,6 +9,8 @@ ARG RELEASE="1"
 RUN microdnf install -y yum \
     && yum -y update-minimal --security --sec-severity=Important --sec-severity=Critical \
     && curl -L -O https://github.com/sigstore/cosign/releases/download/v3.0.2/cosign-3.0.2-1.x86_64.rpm \
+    && echo "7b6ae0f1e8da49d196f89245d4014887747c01c215e2e7f41e4853c98a28ed9b  cosign-3.0.2-1.x86_64.rpm" > cosign-3.0.2-1.x86_64.rpm.sha256 \
+    && sha256sum -c cosign-3.0.2-1.x86_64.rpm.sha256 \
     && rpm -ivh cosign-3.0.2-1.x86_64.rpm \
     && yum clean all \
     && microdnf clean all

--- a/tools/nexus-garbage-collector/Dockerfile
+++ b/tools/nexus-garbage-collector/Dockerfile
@@ -1,6 +1,6 @@
 FROM oci.stackable.tech/sdp/ubi8-rust-builder AS builder
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal AS operator
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10@sha256:578b238953144445a9b5bb2487eb1d95df4886f98d1f73c4a070b27535f51688 AS operator
 
 ARG VERSION
 ARG RELEASE="1"


### PR DESCRIPTION
## Build / deploy hardening (F24, F25, F09)

- **cosign RPM integrity (F24)** — `monitor-oci-artifacts` and `harbor-sbom-browser` downloaded the cosign RPM over HTTPS and `rpm -ivh`'d it with no integrity check. Now verified against a pinned sha256 (`7b6ae0f1…`, confirmed against the real v3.0.2 x86_64 asset) before install.
- **Base-image digest pinning (F25)** — `harbor-gc`/`nexus-gc` now pin `ubi8/ubi-minimal:8.10@sha256:578b2389…`; `monitor-oci` pins `ubi9/ubi-minimal:9.6@sha256:7c5495d5…` (the same digest `harbor-sbom-browser` already uses). Reproducible builds; matches the existing pattern in this repo.
- **Jenkins secret exposure (F09)** — `jobbuilder.groovy` passed `--env JENKINS_PASSWORD=$JENKINS_BOT_PASSWORD`, putting the secret into the `docker run` process arguments (visible via host `ps`). Switched to env pass-through (`--env JENKINS_PASSWORD`).

### Verification
- `hadolint` clean on the changed lines (remaining DL3006/DL3041 are pre-existing — the internal rust-builder base and microdnf version pinning).
- The pinned checksum verifies successfully against the actual downloaded RPM.
- Base-image digests resolved live from `registry.access.redhat.com`.

### Notes
- The internal `oci.stackable.tech/sdp/ubiX-rust-builder` builder stage is left untagged, consistent with the rest of the repo.
- Passing secrets as container env still exposes them via `docker inspect`; fully avoiding that (Docker secrets / files) is a larger change left out here.