### PR TITLE
chore: root .gitignore + sbom-browser license field

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# Python
+__pycache__/
+*.py[cod]
+.ruff_cache/

--- a/tools/harbor-sbom-browser/Cargo.toml
+++ b/tools/harbor-sbom-browser/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "harbor-sbom-browser"
 version = "0.1.0"
+license = "OSL-3.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
Small, decision-free hygiene:

- Root `.gitignore` for Python build cruft (`__pycache__/`, `*.py[cod]`, `.ruff_cache/`) — these were showing up as untracked because there was no root ignore file.
- `license = "OSL-3.0"` in `harbor-sbom-browser/Cargo.toml`, matching the other three tools (F27).

The larger hygiene/dependency items (consolidating the three dependency declarations, tracking `apps/pyproject.toml`/`uv.lock`, triaging the root working-notes and the untracked `auto-retry-tests.py`) need decisions and are intentionally left out of this PR.